### PR TITLE
[FIX] tag xLocEmbarq renomeada para xLocExporta

### DIFF
--- a/pysped/nfe/leiaute/nfe_310.py
+++ b/pysped/nfe/leiaute/nfe_310.py
@@ -52,37 +52,37 @@ DIRNAME = os.path.dirname(__file__)
 class Exporta(XMLNFe):
     def __init__(self):
         super(Exporta, self).__init__()
-        self.UFSaidaPais   = TagCaracter(nome='UFSaidaPais'  , codigo='ZA02', tamanho=[2,  2], raiz='//NFe/infNFe/exporta', obrigatorio=False)
-        self.xLocEmbarq = TagCaracter(nome='xLocEmbarq', codigo='ZA03', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
+        self.UFSaidaPais   = TagCaracter(nome='UFSaidaPais', codigo='ZA02', tamanho=[2,  2], raiz='//NFe/infNFe/exporta', obrigatorio=False)
+        self.xLocExporta = TagCaracter(nome='xLocExporta', codigo='ZA03', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
         self.xLocDespacho = TagCaracter(nome='xLocDespacho', codigo='ZA04', tamanho=[1, 60], raiz='//NFe/infNFe/exporta', obrigatorio=False)
 
     def get_xml(self):
-        if not (self.UFSaidaPais.valor or self.xLocEmbarq.valor):
+        if not (self.UFSaidaPais.valor or self.xLocExporta.valor):
             return ''
 
         xml = XMLNFe.get_xml(self)
         xml += '<exporta>'
         xml += self.UFSaidaPais.xml
-        xml += self.xLocEmbarq.xml
+        xml += self.xLocExporta.xml
         xml += self.xLocDespacho.xml
         xml += '</exporta>'
         return xml
 
     def set_xml(self, arquivo):
         if self._le_xml(arquivo):
-            self.UFSaidaPais.xml   = arquivo
-            self.xLocEmbarq.xml = arquivo
+            self.UFSaidaPais.xml = arquivo
+            self.xLocExporta.xml = arquivo
             self.xLocDespacho.xml = arquivo
 
     xml = property(get_xml, set_xml)
 
     def get_txt(self):
-        if not (self.UFSaidaPais.valor or self.xLocEmbarq.valor):
+        if not (self.UFSaidaPais.valor or self.xLocExporta.valor):
             return ''
 
         txt = 'ZA|'
         txt += self.UFSaidaPais.txt + '|'
-        txt += self.xLocEmbarq.txt + '|'
+        txt += self.xLocExporta.txt + '|'
         txt += self.xLocDespacho.txt + '|'
         txt += '\n'
         return txt
@@ -93,7 +93,7 @@ class Exporta(XMLNFe):
 class InfNFe(nfe_200.InfNFe):
     def __init__(self):
         super(InfNFe, self).__init__()
-        self.exporta  = Exporta()
+        self.exporta = Exporta()
 
 
 class Deduc(nfe_200.Deduc):


### PR DESCRIPTION
Referência: [aqui](http://www.developerflex.com.br/?page=NFeLibrary/Documenta%E7%E3o/Migrando-a-NF-e-2-0-para-3-10-847)

"**Alterações no grupo de identificação da exportação (exporta)**

Também foram feitas algumas alterações no grupo de exportação onde os campos originais UFEmbarq e xLocEmbarq foram renomeados para UFSaidaPais e xLocExporta e o campo sxLocDespacho foi adicionado. ..."
